### PR TITLE
Add session based cart

### DIFF
--- a/components/cart_api.php
+++ b/components/cart_api.php
@@ -1,0 +1,56 @@
+<?php
+session_start();
+require_once 'dbaccess.php';
+require_once 'products.php';
+
+header('Content-Type: application/json');
+
+if (!isset($_SESSION['cart'])) {
+    $_SESSION['cart'] = [];
+}
+
+$action = $_POST['action'] ?? '';
+$id = isset($_POST['id']) ? (int)$_POST['id'] : 0;
+
+if ($action === 'add') {
+    if ($id <= 0) {
+        http_response_code(400);
+        echo json_encode(['success' => false, 'message' => 'Fehlende Produkt-ID.']);
+        exit;
+    }
+    $product = getWohnungById($conn, $id);
+    if (!$product) {
+        http_response_code(404);
+        echo json_encode(['success' => false, 'message' => 'Produkt nicht gefunden.']);
+        exit;
+    }
+
+    if (!isset($_SESSION['cart'][$id])) {
+        $_SESSION['cart'][$id] = [
+            'id' => $product['id'],
+            'name' => $product['name'],
+            'description' => $product['description'],
+            'price' => (float)$product['price'],
+            'qty' => 1
+        ];
+    } else {
+        $_SESSION['cart'][$id]['qty'] += 1;
+    }
+
+    echo json_encode(['success' => true, 'name' => $product['name']]);
+    exit;
+}
+
+if ($action === 'remove') {
+    if ($id > 0 && isset($_SESSION['cart'][$id])) {
+        unset($_SESSION['cart'][$id]);
+        echo json_encode(['success' => true]);
+        exit;
+    }
+    http_response_code(400);
+    echo json_encode(['success' => false, 'message' => 'Produkt nicht gefunden.']);
+    exit;
+}
+
+http_response_code(400);
+echo json_encode(['success' => false, 'message' => 'Ungültige Anfrage.']);

--- a/components/products.php
+++ b/components/products.php
@@ -1,0 +1,47 @@
+<?php
+function getWohnungen(mysqli $conn): array {
+    $wohnungen = [];
+    $stmt = $conn->prepare('SELECT id, name, description, price, image, detail_page FROM wohnungen');
+    if ($stmt && $stmt->execute()) {
+        $result = $stmt->get_result();
+        while ($row = $result->fetch_assoc()) {
+            $wohnungen[] = $row;
+        }
+        $stmt->close();
+    }
+    return $wohnungen;
+}
+
+function getWohnungById(mysqli $conn, int $id): ?array {
+    $stmt = $conn->prepare('SELECT id, name, description, price FROM wohnungen WHERE id = ?');
+    if (!$stmt) {
+        return null;
+    }
+    $stmt->bind_param('i', $id);
+    if (!$stmt->execute()) {
+        $stmt->close();
+        return null;
+    }
+    $result = $stmt->get_result();
+    $data = $result->fetch_assoc();
+    $stmt->close();
+    return $data ?: null;
+}
+
+function searchWohnungen(mysqli $conn, string $query): array {
+    $wohnungen = [];
+    $stmt = $conn->prepare('SELECT id, name, description, price, image, detail_page FROM wohnungen WHERE name LIKE ?');
+    if ($stmt) {
+        $like = '%' . $query . '%';
+        $stmt->bind_param('s', $like);
+        if ($stmt->execute()) {
+            $result = $stmt->get_result();
+            while ($row = $result->fetch_assoc()) {
+                $wohnungen[] = $row;
+            }
+        }
+        $stmt->close();
+    }
+    return $wohnungen;
+}
+?>

--- a/js/cart.js
+++ b/js/cart.js
@@ -1,0 +1,41 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const API_PATH = '../components/cart_api.php';
+
+  document.querySelectorAll('.addToCart').forEach(btn => {
+    btn.addEventListener('click', () => {
+      const id = btn.dataset.id;
+      fetch(API_PATH, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+        body: new URLSearchParams({ action: 'add', id })
+      })
+        .then(res => res.json())
+        .then(data => {
+          if (data.success) {
+            alert(`${data.name} wurde dem Warenkorb hinzugefügt.`);
+          } else {
+            alert(data.message || 'Fehler beim Hinzufügen zum Warenkorb.');
+          }
+        });
+    });
+  });
+
+  document.querySelectorAll('.removeFromCart').forEach(btn => {
+    btn.addEventListener('click', () => {
+      const id = btn.dataset.id;
+      fetch(API_PATH, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+        body: new URLSearchParams({ action: 'remove', id })
+      })
+        .then(res => res.json())
+        .then(data => {
+          if (data.success) {
+            location.reload();
+          } else {
+            alert(data.message || 'Fehler beim Entfernen aus dem Warenkorb.');
+          }
+        });
+    });
+  });
+});

--- a/php/cart.php
+++ b/php/cart.php
@@ -1,0 +1,77 @@
+<?php
+session_start();
+require_once "../components/dbaccess.php";
+
+$cart = $_SESSION['cart'] ?? [];
+?>
+<!DOCTYPE html>
+<html lang="de">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Warenkorb</title>
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.5/dist/css/bootstrap.min.css" rel="stylesheet">
+  <link rel="icon" type="image/png" href="../resources/immohIcon.png">
+  <link rel="stylesheet" href="../css/cssLayout.css">
+</head>
+<body class="replace-bg-dark">
+<?php include("../components/header.php"); ?>
+<main>
+  <nav aria-label="breadcrumb">
+    <ol class="breadcrumb mt-3 ms-2">
+      <li class="breadcrumb-item"><a class="text-decoration-none replace-link-dark" href="index.php"><i class="fas fa-home"></i> ImmOH!</a></li>
+      <li class="breadcrumb-item active" aria-current="page">Warenkorb</li>
+    </ol>
+  </nav>
+  <div class="container py-4">
+    <h2>Warenkorb</h2>
+    <table class="table">
+      <thead>
+        <tr>
+          <th>Name</th>
+          <th>Anteile</th>
+          <th>Beschreibung</th>
+          <th>Preis</th>
+          <th>Summe</th>
+          <th></th>
+        </tr>
+      </thead>
+      <tbody>
+        <?php
+        $total = 0;
+        if (empty($cart)) : ?>
+          <tr>
+            <td colspan="6" class="text-center">Ihr Warenkorb ist leer.</td>
+          </tr>
+        <?php else:
+          foreach ($cart as $item) :
+            $sum = $item['price'] * $item['qty'];
+            $total += $sum; ?>
+            <tr>
+              <td><?= htmlspecialchars($item['name']) ?></td>
+              <td><?= (int)$item['qty'] ?></td>
+              <td><?= htmlspecialchars($item['description']) ?></td>
+              <td>€<?= number_format($item['price'], 2, ',', '.') ?></td>
+              <td>€<?= number_format($sum, 2, ',', '.') ?></td>
+              <td><button class="btn btn-sm btn-danger removeFromCart" data-id="<?= htmlspecialchars($item['id']) ?>">Entfernen</button></td>
+            </tr>
+          <?php endforeach;
+        endif; ?>
+      </tbody>
+      <tfoot>
+        <tr>
+          <th colspan="3" class="text-end">Gesamt:</th>
+          <th id="cart-total">€<?= number_format($total, 2, ',', '.') ?></th>
+          <th></th>
+        </tr>
+      </tfoot>
+    </table>
+    <div class="text-end">
+      <a href="kassa.php" class="btn btn-primary <?= empty($cart) ? 'disabled' : '' ?>">Zur Kasse</a>
+    </div>
+  </div>
+</main>
+<?php include("../components/footer.php"); ?>
+<script src="../js/cart.js"></script>
+</body>
+</html>

--- a/php/kassa.php
+++ b/php/kassa.php
@@ -1,1 +1,77 @@
+<?php
+session_start();
+require_once "../components/dbaccess.php";
 
+$cart = $_SESSION['cart'] ?? [];
+$vatRate = 0.20;
+$subtotal = 0;
+foreach ($cart as $item) {
+    $subtotal += $item['price'] * $item['qty'];
+}
+$tax = $subtotal * $vatRate;
+$total = $subtotal + $tax;
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST' && !empty($cart)) {
+    $_SESSION['cart'] = [];
+    $_SESSION['meldung'] = 'Bestellung abgeschlossen. Vielen Dank!';
+    header('Location: index.php');
+    exit;
+}
+?>
+<!DOCTYPE html>
+<html lang="de">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Kassa</title>
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.5/dist/css/bootstrap.min.css" rel="stylesheet">
+  <link rel="icon" type="image/png" href="../resources/immohIcon.png">
+  <link rel="stylesheet" href="../css/cssLayout.css">
+</head>
+<body class="replace-bg-dark">
+<?php include("../components/header.php"); ?>
+<main>
+  <nav aria-label="breadcrumb">
+    <ol class="breadcrumb mt-3 ms-2">
+      <li class="breadcrumb-item"><a class="text-decoration-none replace-link-dark" href="index.php"><i class="fas fa-home"></i> ImmOH!</a></li>
+      <li class="breadcrumb-item active" aria-current="page">Kassa</li>
+    </ol>
+  </nav>
+  <?php if (empty($cart)): ?>
+    <p>Ihr Warenkorb ist leer.</p>
+  <?php else: ?>
+    <h2>Übersicht</h2>
+    <table class="table">
+      <thead>
+        <tr>
+          <th>Produkt</th>
+          <th>Menge</th>
+          <th>Preis</th>
+          <th>Summe</th>
+        </tr>
+      </thead>
+      <tbody>
+        <?php foreach ($cart as $item): $sum = $item['price'] * $item['qty']; ?>
+        <tr>
+          <td><?= htmlspecialchars($item['name']) ?></td>
+          <td><?= (int)$item['qty'] ?></td>
+          <td>€<?= number_format($item['price'], 2, ',', '.') ?></td>
+          <td>€<?= number_format($sum, 2, ',', '.') ?></td>
+        </tr>
+        <?php endforeach; ?>
+      </tbody>
+      <tfoot>
+        <tr><th colspan="3" class="text-end">Zwischensumme:</th><td>€<?= number_format($subtotal, 2, ',', '.') ?></td></tr>
+        <tr><th colspan="3" class="text-end">Immobilienabgabe (<?= $vatRate*100 ?>%):</th><td>€<?= number_format($tax, 2, ',', '.') ?></td></tr>
+        <tr><th colspan="3" class="text-end">Gesamt:</th><td>€<?= number_format($total, 2, ',', '.') ?></td></tr>
+      </tfoot>
+    </table>
+    <form method="post">
+      <button type="submit" class="btn btn-primary">Bestellung abschließen</button>
+    </form>
+  <?php endif; ?>
+</main>
+<?php include("../components/footer.php"); ?>
+<script src="../js/function.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- implement shopping cart API
- add JS to send add/remove requests
- show cart and checkout pages
- helper functions for accessing `wohnungen` table

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68610d8f3de48326ab1a3b0ad741925d